### PR TITLE
bind Ctrl-P to golineup

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -16,6 +16,9 @@ var emitter = new EventEmitter();
 $(window).on("load", function() {
     editor = ace.edit("text");
     editor.$blockScrolling = Infinity;
+    if (process.platform === "darwin") {
+        editor.commands.bindKey("Ctrl-P", "golineup");
+    }
     editor.setTheme("ace/theme/monokai");
     setInterval(function() {
         if (editor.getValue() !== EDITOR_FILE_VALUE) {


### PR DESCRIPTION
Fix for moving to previous line with Ctrl-P.

Just a workaround, so maybe we should find the root cause. Or maybe use this fix for meanwhile.
reference : http://qiita.com/okaxaki/items/ee36d9732c3c4a64c4e4
